### PR TITLE
Generalize parser to support other Comparable classes

### DIFF
--- a/Sources/Domain/Date/Date+RangeParsable.swift
+++ b/Sources/Domain/Date/Date+RangeParsable.swift
@@ -1,0 +1,27 @@
+//
+//  Date+RangeParsable.swift
+//  Uppsala
+//
+//  Created by Suita Fujino on 2019/01/06.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+/**
+ A model class which describes a notificarion date.
+ */
+extension Date: RangeParsable {
+    
+    // (InheritDoc)
+    static let prefixForPreprocess: String = ""
+    // (InheritDoc)
+    static let suffixForPreprocess: String = ""
+    // (InheritDoc)
+    static func from(_ str: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
+        dateFormatter.locale = Locale.current
+        
+        return dateFormatter.date(from: str)
+    }
+    
+}

--- a/Sources/Domain/Date/Date+RangeParsable.swift
+++ b/Sources/Domain/Date/Date+RangeParsable.swift
@@ -12,10 +12,6 @@
 extension Date: RangeParsable {
     
     // (InheritDoc)
-    static let prefixForPreprocess: String = ""
-    // (InheritDoc)
-    static let suffixForPreprocess: String = ""
-    // (InheritDoc)
     static func from(_ str: String) -> Date? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"

--- a/Sources/Domain/Parser/RangeParsable.swift
+++ b/Sources/Domain/Parser/RangeParsable.swift
@@ -1,0 +1,30 @@
+//
+//  RangeParsable.swift
+//  Uppsala
+//
+//  Created by Suita Fujino on 2019/01/06.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+protocol RangeParsableFactory {
+    
+    associatedtype ImplType
+    
+    /**
+     Failable intializer from `String`.
+     
+     - Parameters:
+     - str: The characters to parse.
+     */
+    static func from(_ str: String) -> ImplType?
+}
+
+protocol RangeParsable: Comparable, RangeParsableFactory where ImplType == Self {
+    
+    /// The prefix for parse preprocessing.
+    static var prefixForPreprocess: String { get }
+    
+    /// The suffix for parse preprocessing.
+    static var suffixForPreprocess: String { get }
+    
+}

--- a/Sources/Domain/Parser/RangeParsable.swift
+++ b/Sources/Domain/Parser/RangeParsable.swift
@@ -19,12 +19,4 @@ protocol RangeParsableFactory {
     static func from(_ str: String) -> ImplType?
 }
 
-protocol RangeParsable: Comparable, RangeParsableFactory where ImplType == Self {
-    
-    /// The prefix for parse preprocessing.
-    static var prefixForPreprocess: String { get }
-    
-    /// The suffix for parse preprocessing.
-    static var suffixForPreprocess: String { get }
-    
-}
+protocol RangeParsable: Comparable, RangeParsableFactory where ImplType == Self {}

--- a/Sources/Domain/Parser/RangeParsable.swift
+++ b/Sources/Domain/Parser/RangeParsable.swift
@@ -14,7 +14,7 @@ protocol RangeParsableFactory {
      Failable intializer from `String`.
      
      - Parameters:
-     - str: The characters to parse.
+       - str: The characters to parse.
      */
     static func from(_ str: String) -> ImplType?
 }

--- a/Sources/Domain/Parser/RangeParser.swift
+++ b/Sources/Domain/Parser/RangeParser.swift
@@ -15,7 +15,7 @@ final class RangeParser {
     public enum ParseError: Error {
         /// Invalid range format. (e.g. 0.1<)
         case invalidRangeFormat(String)
-        /// Invalid value format. (e.g. 0.1..2)
+        /// Invalid value format. (e.g. 0.1..2<1.2)
         case invalidValueFormat(String)
     }
     
@@ -26,11 +26,13 @@ final class RangeParser {
      
      Here the example with `SemanticVersion`
      ```
-     0.0<1.1.2 // acceptable
+     0.1<1.1.2 // acceptable
+     0.1<=1.1.2 // acceptable
+     <=1.1.2 // acceptable
      <1.1.2 // accetable
-     1.1.2 // acceptable (and equivalent to 1.1.2<1.1.2.1)
+     =1.1.2 // accetable
+     1.1.2 // acceptable (and equivalent to =1.1.2)
      1.1.2< // NOT acceptable
-     <=1.1.2 // NOT acceptable
      ```
      
      - Parameters:

--- a/Sources/Domain/Parser/RangeParser.swift
+++ b/Sources/Domain/Parser/RangeParser.swift
@@ -1,5 +1,5 @@
 //
-//  SemanticVersionRangeParser.swift
+//  RangeParser.swift
 //  Uppsala
 //
 //  Created by Suita Fujino on 2019/01/01.
@@ -7,11 +7,9 @@
 //
 
 /**
- A parser for the semi-open range of `SemanticVersion`.
+ A parser for the semi-open range `String`s.
  */
-public final class SemanticVersionRangeParser {
-    
-    public typealias Result = UppsalaResult<Range<SemanticVersion>, ParseError>
+final class RangeParser {
     
     /// Error occurred on parsing.
     public enum ParseError: Error {
@@ -24,7 +22,7 @@ public final class SemanticVersionRangeParser {
     // MARK: - Methods
     
     /**
-     Parses from the given pattern to the semi-open range of `SemanticVersion`.
+     Parses from the given pattern to the semi-open range of `T: RangeParsable`.
      
      NOTE: The pattern which confirms to `^[0-9.<]+[0-9]+$` is acceptable.
      ```
@@ -38,10 +36,10 @@ public final class SemanticVersionRangeParser {
      - Parameters:
        - str: The pattern represents the semi-open range.
      
-     - Returns: The combined `Result` of Range<SemanticVersion> and `ParseError`.
+     - Returns: The combined `Result` of Range<T> and `ParseError`.
      */
-    public func parse(from str: String) -> Result {
-        let pattern = "0" + str.replacingOccurrences(of: " ", with: "")
+    func parse<T: RangeParsable>(from str: String, to: T.Type) -> UppsalaResult<Range<T>, ParseError> {
+        let pattern = T.prefixForPreprocess + str.replacingOccurrences(of: " ", with: "")
         guard pattern.isMatching(regex: "^[0-9.<]+[0-9]+$") else { return .error(.invalidFormat(pattern)) }
         
         var split = pattern.split(separator: "<")
@@ -54,11 +52,11 @@ public final class SemanticVersionRangeParser {
             return .error(.invalidFormat(str))
         }
         
-        let range = split.compactMap({ SemanticVersion(from: String($0)) })
+        let range = split.compactMap({ T.from(String($0)) })
         if range.count != 2 {
             return .error(.invalidVersionFormat(str))
         }
         
-        return Result.ok(range[0]..<range[1])
+        return UppsalaResult.ok(range[0]..<range[1])
     }
 }

--- a/Sources/Domain/Parser/UppsalaRange.swift
+++ b/Sources/Domain/Parser/UppsalaRange.swift
@@ -1,0 +1,70 @@
+//
+//  UppsalaRange.swift
+//  Uppsala
+//
+//  Created by Suita Fujino on 2019/01/20.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+public final class UppsalaRange<T: Comparable> {
+    
+    // MARK: - Properties
+    
+    /// The left side value of the range.
+    public let left: T?
+    /// The right side value of the range.
+    public let right: T?
+    
+    /// Whether the right side value is contained.
+    public let isContainingRightSide: Bool
+    
+    // MARK: - Lifecycle
+    
+    /**
+     Initializer.
+     
+     - Parameters:
+       - lhs: The left side of the range.
+       - rhs: The right side of the range.
+       - isContainingRightSide: Whether the right side value is contained.
+     */
+    public init(lhs: T? = nil, rhs: T? = nil, isContainingRightSide: Bool = true) {
+        left = lhs
+        right = rhs
+        self.isContainingRightSide = isContainingRightSide
+    }
+    
+    // MARK: - Methods
+    
+    /**
+     Returns whether the range contains the target value.
+     
+     - Parameters:
+       - target: The target value.
+     
+     - Returns: Whether the range contains the target value.
+     */
+    public func contains(_ target: T) -> Bool {
+        switch (left, right, isContainingRightSide) {
+        case (.some(let left), .some(let right), true):
+            return (left...right).contains(target)
+        case (.some(let left), .some(let right), false):
+            return (left..<right).contains(target)
+        case (.some(let left), .none, _):
+            return (left...).contains(target)
+        case (.none, .some(let right), true):
+            return (...right).contains(target)
+        case (.none, .some(let right), false):
+            return (..<right).contains(target)
+        case (.none, .none, _):
+            return true
+        }
+    }
+    
+}
+
+extension UppsalaRange: Equatable {
+    public static func == (lhs: UppsalaRange<T>, rhs: UppsalaRange<T>) -> Bool {
+        return lhs.left == rhs.left && lhs.right == rhs.right && lhs.isContainingRightSide == rhs.isContainingRightSide
+    }
+}

--- a/Sources/Domain/Update/UpdateDetail.swift
+++ b/Sources/Domain/Update/UpdateDetail.swift
@@ -25,7 +25,7 @@ public final class UpdateDetail {
     public let title: String?
     
     /// The range of the app version to update.
-    public let version: Range<SemanticVersion>
+    public let version: UppsalaRange<SemanticVersion>
     
     // MARK: - Lifecycle
     

--- a/Sources/Domain/Update/UpdateDetail.swift
+++ b/Sources/Domain/Update/UpdateDetail.swift
@@ -37,9 +37,9 @@ public final class UpdateDetail {
      
      - throws: `ConversionError`
      */
-    init(from entity: UpdateDetailJSONEntity, parser: SemanticVersionRangeParser = SemanticVersionRangeParser()) throws {
+    init(from entity: UpdateDetailJSONEntity, parser: RangeParser = RangeParser()) throws {
         guard let appStoreUrl = URL(string: entity.appStoreUrl) else { throw ConversionError.failedToConvert(entity.appStoreUrl) }
-        guard let version = parser.parse(from: entity.version).ok() else { throw ConversionError.failedToConvert(entity.version) }
+        guard let version = parser.parse(from: entity.version, to: SemanticVersion.self).ok() else { throw ConversionError.failedToConvert(entity.version) }
         
         self.appStoreUrl = appStoreUrl
         self.message = entity.message

--- a/Sources/Domain/Versioning/SemanticVersion.swift
+++ b/Sources/Domain/Versioning/SemanticVersion.swift
@@ -15,11 +15,6 @@ public class SemanticVersion: Comparable, CustomStringConvertible, RangeParsable
     
     // MARK: - Properties
     
-    // (InheritDoc)
-    static let prefixForPreprocess: String = "0"
-    // (InheritDoc)
-    static let suffixForPreprocess: String = ".1"
-    
     /// The array of split number.
     public var splitVersionNumber: [VersionDataType] = []
     

--- a/Sources/Domain/Versioning/SemanticVersion.swift
+++ b/Sources/Domain/Versioning/SemanticVersion.swift
@@ -16,9 +16,9 @@ public class SemanticVersion: Comparable, CustomStringConvertible, RangeParsable
     // MARK: - Properties
     
     // (InheritDoc)
-    public static let prefixForPreprocess: String = "0"
+    static let prefixForPreprocess: String = "0"
     // (InheritDoc)
-    public static let suffixForPreprocess: String = ".1"
+    static let suffixForPreprocess: String = ".1"
     
     /// The array of split number.
     public var splitVersionNumber: [VersionDataType] = []
@@ -59,7 +59,7 @@ public class SemanticVersion: Comparable, CustomStringConvertible, RangeParsable
     
     // MARK: - Methods
     
-    public class func from(_ str: String) -> SemanticVersion? {
+    class func from(_ str: String) -> SemanticVersion? {
         return SemanticVersion(from: str)
     }
 

--- a/Sources/Domain/Versioning/SemanticVersion.swift
+++ b/Sources/Domain/Versioning/SemanticVersion.swift
@@ -9,11 +9,16 @@
 /**
  A model class which describes a semantic version.
  */
-public class SemanticVersion: Comparable, CustomStringConvertible {
+public class SemanticVersion: Comparable, CustomStringConvertible, RangeParsable {
     
     public typealias VersionDataType = UInt32
     
     // MARK: - Properties
+    
+    // (InheritDoc)
+    public static let prefixForPreprocess: String = "0"
+    // (InheritDoc)
+    public static let suffixForPreprocess: String = ".1"
     
     /// The array of split number.
     public var splitVersionNumber: [VersionDataType] = []
@@ -36,7 +41,7 @@ public class SemanticVersion: Comparable, CustomStringConvertible {
      - Parameters:
        - str: The characters to parse.
      */
-    init?(from str: String) {
+    required public init?(from str: String) {
         var result: [VersionDataType] = []
         if str.isEmpty {
             splitVersionNumber = [0]
@@ -53,6 +58,10 @@ public class SemanticVersion: Comparable, CustomStringConvertible {
     }
     
     // MARK: - Methods
+    
+    public class func from(_ str: String) -> SemanticVersion? {
+        return SemanticVersion(from: str)
+    }
 
 }
 

--- a/Tests/Domain/Parser/RangeParserTests.swift
+++ b/Tests/Domain/Parser/RangeParserTests.swift
@@ -1,5 +1,5 @@
 //
-//  SemanticVersionRangeParserTests.swift
+//  RangeParserTests.swift
 //  UppsalaTests
 //
 //  Created by Suita Fujino on 2019/01/01.
@@ -9,12 +9,12 @@
 import XCTest
 @testable import Uppsala
 
-class SemanticVersionRangeParserTests: XCTestCase {
+class RangeParserTests: XCTestCase {
     
-    let parser = SemanticVersionRangeParser()
+    let parser = RangeParser()
 
     func testParseWithBothDefinedRange() {
-        let parseResult = parser.parse(from: "0.1.1 < 1.2")
+        let parseResult = parser.parse(from: "0.1.1 < 1.2", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
             XCTFail("\(parseResult.error()!)")
             return
@@ -34,7 +34,7 @@ class SemanticVersionRangeParserTests: XCTestCase {
     }
     
     func testParseWithRightDefinedRange() {
-        let parseResult = parser.parse(from: "<2.0")
+        let parseResult = parser.parse(from: "<2.0", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
             XCTFail("\(parseResult.error()!)")
             return
@@ -48,7 +48,7 @@ class SemanticVersionRangeParserTests: XCTestCase {
     }
     
     func testParseWithSingleValue() {
-        let parseResult = parser.parse(from: "1.12")
+        let parseResult = parser.parse(from: "1.12", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
             XCTFail("\(parseResult.error()!)")
             return
@@ -62,7 +62,7 @@ class SemanticVersionRangeParserTests: XCTestCase {
     }
     
     func testParseWithInvalidFormat() {
-        let parseResult = parser.parse(from: "+2.2")
+        let parseResult = parser.parse(from: "+2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
             return
@@ -77,7 +77,7 @@ class SemanticVersionRangeParserTests: XCTestCase {
     }
     
     func testParseWithInvalidFormat2() {
-        let parseResult = parser.parse(from: "1.0<1.1<2.2")
+        let parseResult = parser.parse(from: "1.0<1.1<2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
             return
@@ -92,7 +92,7 @@ class SemanticVersionRangeParserTests: XCTestCase {
     }
     
     func testParseWithInvalidVersionFormat() {
-        let parseResult = parser.parse(from: "1.1...<2.2")
+        let parseResult = parser.parse(from: "1.1...<2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
             return

--- a/Tests/Domain/Parser/RangeParserTestsForDate.swift
+++ b/Tests/Domain/Parser/RangeParserTestsForDate.swift
@@ -27,6 +27,21 @@ class RangeParserTestsForDate: XCTestCase {
         XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
     }
     
+    func testParseWithBothDefinedRangeWithEqual() {
+        let parseResult = parser.parse(from: "2018-11-11T00:00 <=2018-12-01T00:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(Date.from("2018-11-11T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-12T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-30T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-12-1T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2018-12-1T00:01")!))
+        XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
+    }
+    
     func testParseWithRightDefinedRange() {
         let parseResult = parser.parse(from: "<2018-12-01T00:00", to: Date.self)
         guard let range = parseResult.ok() else {
@@ -41,19 +56,43 @@ class RangeParserTestsForDate: XCTestCase {
         XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
     }
     
-//    func testParseWithSingleValue() {
-//        let parseResult = parser.parse(from: "1.12", to: SemanticVersion.self)
-//        guard let range = parseResult.ok() else {
-//            XCTFail("\(parseResult.error()!)")
-//            return
-//        }
-//
-//        XCTAssert(range.contains(SemanticVersion(from: "1.12")!))
-//        XCTAssert(range.contains(SemanticVersion(from: "1.12.0")!))
-//        XCTAssert(range.contains(SemanticVersion(from: "1.12.0.1")!))
-//        XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.1")!))
-//        XCTAssertFalse(range.contains(SemanticVersion(from: "2")!))
-//    }
+    func testParseWithRightDefinedRangeWithEqual() {
+        let parseResult = parser.parse(from: "<=2018-12-01T00:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(Date.from("2015-10-10T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-12T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-12-1T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2019-1-1T00:01")!))
+        XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
+    }
+    
+    func testParseWithSingleValue() {
+        let parseResult = parser.parse(from: "2019-01-01T09:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+
+        XCTAssert(range.contains(Date.from("2019-01-01T09:00")!))
+        XCTAssertFalse(range.contains(Date.from("2019-01-02T09:01")!))
+        XCTAssertFalse(range.contains(Date.from("2019-01-02T09:00")!))
+    }
+    
+    func testParseWithSingleValueWithEqual() {
+        let parseResult = parser.parse(from: "=2019-01-01T09:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(Date.from("2019-01-01T09:00")!))
+        XCTAssertFalse(range.contains(Date.from("2019-01-02T09:01")!))
+        XCTAssertFalse(range.contains(Date.from("2019-01-02T09:00")!))
+    }
     
     func testParseWithInvalidRangeFormat() {
         let parseResult = parser.parse(from: "<<2018-12-01T00:00", to: Date.self)

--- a/Tests/Domain/Parser/RangeParserTestsForDate.swift
+++ b/Tests/Domain/Parser/RangeParserTestsForDate.swift
@@ -1,0 +1,103 @@
+//
+//  RangeParserTestsForDate.swift
+//  UppsalaTests
+//
+//  Created by Suita Fujino on 2019/01/06.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+import XCTest
+@testable import Uppsala
+
+class RangeParserTestsForDate: XCTestCase {
+
+    let parser = RangeParser()
+    
+    func testParseWithBothDefinedRange() {
+        let parseResult = parser.parse(from: "2018-11-11T00:00 < 2018-12-01T00:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(Date.from("2018-11-11T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-12T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-30T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2018-12-1T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
+    }
+    
+    func testParseWithRightDefinedRange() {
+        let parseResult = parser.parse(from: "<2018-12-01T00:00", to: Date.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(Date.from("2015-10-10T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-12T00:00")!))
+        XCTAssert(range.contains(Date.from("2018-11-30T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2018-12-1T00:00")!))
+        XCTAssertFalse(range.contains(Date.from("2019-1-1T00:00")!))
+    }
+    
+//    func testParseWithSingleValue() {
+//        let parseResult = parser.parse(from: "1.12", to: SemanticVersion.self)
+//        guard let range = parseResult.ok() else {
+//            XCTFail("\(parseResult.error()!)")
+//            return
+//        }
+//
+//        XCTAssert(range.contains(SemanticVersion(from: "1.12")!))
+//        XCTAssert(range.contains(SemanticVersion(from: "1.12.0")!))
+//        XCTAssert(range.contains(SemanticVersion(from: "1.12.0.1")!))
+//        XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.1")!))
+//        XCTAssertFalse(range.contains(SemanticVersion(from: "2")!))
+//    }
+    
+    func testParseWithInvalidRangeFormat() {
+        let parseResult = parser.parse(from: "<<2018-12-01T00:00", to: Date.self)
+        guard let error = parseResult.error() else {
+            XCTFail("\(parseResult.ok()!)")
+            return
+        }
+        
+        switch error {
+        case .invalidRangeFormat:
+            break
+        default:
+            XCTFail("Unexpected error returned")
+        }
+    }
+    
+    func testParseWithInvalidRangeFormat2() {
+        let parseResult = parser.parse(from: "2017-11-11T00:00<2018-11-11T00:00<2018-12-01T00:00", to: SemanticVersion.self)
+        guard let error = parseResult.error() else {
+            XCTFail("\(parseResult.ok()!)")
+            return
+        }
+        
+        switch error {
+        case .invalidRangeFormat:
+            break
+        default:
+            XCTFail("Unexpected error returned")
+        }
+    }
+    
+    func testParseWithInvalidValueFormat() {
+        let parseResult = parser.parse(from: "2018/11/11T00:00<2018-12-01T00:00", to: SemanticVersion.self)
+        guard let error = parseResult.error() else {
+            XCTFail("\(parseResult.ok()!)")
+            return
+        }
+        
+        switch error {
+        case .invalidValueFormat:
+            break
+        default:
+            XCTFail("Unexpected error returned")
+        }
+    }
+
+}

--- a/Tests/Domain/Parser/RangeParserTestsForSemanticVersion.swift
+++ b/Tests/Domain/Parser/RangeParserTestsForSemanticVersion.swift
@@ -1,5 +1,5 @@
 //
-//  RangeParserTests.swift
+//  RangeParserTestsForSemanticVersion.swift
 //  UppsalaTests
 //
 //  Created by Suita Fujino on 2019/01/01.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import Uppsala
 
-class RangeParserTests: XCTestCase {
+class RangeParserTestsForSemanticVersion: XCTestCase {
     
     let parser = RangeParser()
 
@@ -48,7 +48,7 @@ class RangeParserTests: XCTestCase {
     }
     
     func testParseWithSingleValue() {
-        let parseResult = parser.parse(from: "1.12", to: SemanticVersion.self)
+        let parseResult = parser.parse(from: "=1.12", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
             XCTFail("\(parseResult.error()!)")
             return
@@ -56,27 +56,27 @@ class RangeParserTests: XCTestCase {
         
         XCTAssert(range.contains(SemanticVersion(from: "1.12")!))
         XCTAssert(range.contains(SemanticVersion(from: "1.12.0")!))
-        XCTAssert(range.contains(SemanticVersion(from: "1.12.0.1")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.0.1")!))
         XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.1")!))
         XCTAssertFalse(range.contains(SemanticVersion(from: "2")!))
     }
     
-    func testParseWithInvalidFormat() {
-        let parseResult = parser.parse(from: "+2.2", to: SemanticVersion.self)
+    func testParseWithInvalidRangeFormat() {
+        let parseResult = parser.parse(from: "<<2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
             return
         }
         
         switch error {
-        case .invalidFormat:
+        case .invalidRangeFormat:
             break
         default:
             XCTFail("Unexpected error returned")
         }
     }
     
-    func testParseWithInvalidFormat2() {
+    func testParseWithInvalidRangeFormat2() {
         let parseResult = parser.parse(from: "1.0<1.1<2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
@@ -84,14 +84,14 @@ class RangeParserTests: XCTestCase {
         }
         
         switch error {
-        case .invalidFormat:
+        case .invalidRangeFormat:
             break
         default:
             XCTFail("Unexpected error returned")
         }
     }
     
-    func testParseWithInvalidVersionFormat() {
+    func testParseWithInvalidValueFormat() {
         let parseResult = parser.parse(from: "1.1...<2.2", to: SemanticVersion.self)
         guard let error = parseResult.error() else {
             XCTFail("\(parseResult.ok()!)")
@@ -99,7 +99,7 @@ class RangeParserTests: XCTestCase {
         }
         
         switch error {
-        case .invalidVersionFormat:
+        case .invalidValueFormat:
             break
         default:
             XCTFail("Unexpected error returned")

--- a/Tests/Domain/Parser/RangeParserTestsForSemanticVersion.swift
+++ b/Tests/Domain/Parser/RangeParserTestsForSemanticVersion.swift
@@ -33,6 +33,26 @@ class RangeParserTestsForSemanticVersion: XCTestCase {
         XCTAssertFalse(range.contains(SemanticVersion(from: "1.2.0.1")!))
     }
     
+    func testParseWithBothDefinedRangeWithEqual() {
+        let parseResult = parser.parse(from: "0.1.1 <= 1.2", to: SemanticVersion.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(SemanticVersion(from: "0.1.1.1")!))
+        XCTAssert(range.contains(SemanticVersion(from: "0.1.1")!))
+        XCTAssert(range.contains(SemanticVersion(from: "0.1.1.0")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "0.1")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "0.0.1")!))
+        
+        XCTAssert(range.contains(SemanticVersion(from: "1.1")!))
+        XCTAssert(range.contains(SemanticVersion(from: "1.1.12")!))
+        XCTAssert(range.contains(SemanticVersion(from: "1.2")!))
+        XCTAssert(range.contains(SemanticVersion(from: "1.2.0")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "1.2.0.1")!))
+    }
+    
     func testParseWithRightDefinedRange() {
         let parseResult = parser.parse(from: "<2.0", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
@@ -47,7 +67,35 @@ class RangeParserTestsForSemanticVersion: XCTestCase {
         XCTAssertFalse(range.contains(SemanticVersion(from: "2.0.1")!))
     }
     
+    func testParseWithRightDefinedRangeWithEqual() {
+        let parseResult = parser.parse(from: "<=2.0", to: SemanticVersion.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(SemanticVersion(from: "1.12")!))
+        XCTAssert(range.contains(SemanticVersion(from: "1.12.1")!))
+        XCTAssert(range.contains(SemanticVersion(from: "2")!))
+        XCTAssert(range.contains(SemanticVersion(from: "2.0")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "2.0.1")!))
+    }
+    
     func testParseWithSingleValue() {
+        let parseResult = parser.parse(from: "1.12", to: SemanticVersion.self)
+        guard let range = parseResult.ok() else {
+            XCTFail("\(parseResult.error()!)")
+            return
+        }
+        
+        XCTAssert(range.contains(SemanticVersion(from: "1.12")!))
+        XCTAssert(range.contains(SemanticVersion(from: "1.12.0")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.0.1")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "1.12.1")!))
+        XCTAssertFalse(range.contains(SemanticVersion(from: "2")!))
+    }
+    
+    func testParseWithSingleValueWithEqual() {
         let parseResult = parser.parse(from: "=1.12", to: SemanticVersion.self)
         guard let range = parseResult.ok() else {
             XCTFail("\(parseResult.error()!)")

--- a/Tests/Domain/Update/UpdateDetailTests.swift
+++ b/Tests/Domain/Update/UpdateDetailTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 fileprivate struct Constants {
     static let testAppStoreUrl = "https://www.apple.com"
-    static let testVersion = "<1.1.12"
+    static let testVersion = "<=1.1.12"
     static let testInvalidVersion = "<1.1..12"
 }
 
@@ -19,10 +19,13 @@ class UpdateDetailTests: XCTestCase {
 
     func testIntializerShouldSucceed() {
         let entity = UpdateDetailJSONEntity(appStoreUrl: Constants.testAppStoreUrl, message: nil, title: nil, version: Constants.testVersion)
-        let updateDetail = try? UpdateDetail(from: entity)
+        guard let updateDetail = try? UpdateDetail(from: entity) else {
+            XCTFail("Unexpected nil")
+            return
+        }
         
-        let expectedRange = SemanticVersion(from: "0")!..<SemanticVersion(from: "1.1.12")!
-        XCTAssertEqual(updateDetail?.version, expectedRange)
+        let expectedRange = UppsalaRange(lhs: nil, rhs: SemanticVersion(from: "1.1.12")!, isContainingRightSide: true)
+        XCTAssertEqual(updateDetail.version, expectedRange)
     }
     
     func testIntializerShouldReturnNil() {

--- a/Tests/Presentation/Gateway/UpdateDetailFetcherTests.swift
+++ b/Tests/Presentation/Gateway/UpdateDetailFetcherTests.swift
@@ -27,7 +27,8 @@ class UpdateDetailFetcherTests: XCTestCase {
     }
     
     func testFetchAwaitShouldSucceed() {
-        XCTAssert(UpdateDetailFetcher().fetchAwait(from: testURL).isOk())
+        let result = UpdateDetailFetcher().fetchAwait(from: testURL)
+        XCTAssert(result.isOk())
     }
 
 }

--- a/Uppsala.xcodeproj/project.pbxproj
+++ b/Uppsala.xcodeproj/project.pbxproj
@@ -7,11 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6B7C0FEA21E203B200B0A6CD /* RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */; };
+		6B7C0FEE21E20FEF00B0A6CD /* Date+RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C0FED21E20FEF00B0A6CD /* Date+RangeParsable.swift */; };
+		6B7C0FF221E212AF00B0A6CD /* RangeParserTestsForDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C0FF121E212AF00B0A6CD /* RangeParserTestsForDate.swift */; };
 		6B8ABEE621E093F700972E26 /* UpdateDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEE521E093F700972E26 /* UpdateDetail.swift */; };
 		6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */; };
 		6B8ABEEC21E0C32000972E26 /* Uppsala+fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */; };
 		6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEF021E0D3FF00972E26 /* DialogTexts.swift */; };
+		6BD0F15721F475BB00519EB7 /* UppsalaRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */; };
+		6BD0F15921F4873200519EB7 /* RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15821F4873200519EB7 /* RangeParsable.swift */; };
 		6BFF5EFE21DA1EB800F4FBBB /* Uppsala.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */; };
 		6BFF5F0521DA1EB800F4FBBB /* Uppsala.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BFF5EF721DA1EB700F4FBBB /* Uppsala.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BFF5F0F21DA43BC00F4FBBB /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F0E21DA43BC00F4FBBB /* SemanticVersion.swift */; };
@@ -28,7 +31,7 @@
 		6BFF5F8121DB50F000F4FBBB /* AlertControllerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F8021DB50F000F4FBBB /* AlertControllerFactoryTests.swift */; };
 		6BFF5F9321DB658700F4FBBB /* RangeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9221DB658700F4FBBB /* RangeParser.swift */; };
 		6BFF5F9521DB6A5F00F4FBBB /* UppsalaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9421DB6A5F00F4FBBB /* UppsalaResult.swift */; };
-		6BFF5F9721DB80A500F4FBBB /* RangeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */; };
+		6BFF5F9721DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9621DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift */; };
 		6BFF5F9A21DB887400F4FBBB /* String+match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9921DB887400F4FBBB /* String+match.swift */; };
 		6BFF5F9F21DB8CE100F4FBBB /* UppsalaResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9E21DB8CE100F4FBBB /* UppsalaResultTests.swift */; };
 		6BFF5FA221DC751000F4FBBB /* UpdateDetailJSONEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5FA121DC751000F4FBBB /* UpdateDetailJSONEntity.swift */; };
@@ -51,11 +54,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
+		6B7C0FED21E20FEF00B0A6CD /* Date+RangeParsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+RangeParsable.swift"; sourceTree = "<group>"; };
+		6B7C0FF121E212AF00B0A6CD /* RangeParserTestsForDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParserTestsForDate.swift; sourceTree = "<group>"; };
 		6B8ABEE521E093F700972E26 /* UpdateDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetail.swift; sourceTree = "<group>"; };
 		6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetailTests.swift; sourceTree = "<group>"; };
 		6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Uppsala+fetch.swift"; sourceTree = "<group>"; };
 		6B8ABEF021E0D3FF00972E26 /* DialogTexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DialogTexts.swift; path = Sources/Domain/Update/DialogTexts.swift; sourceTree = SOURCE_ROOT; };
+		6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaRange.swift; sourceTree = "<group>"; };
+		6BD0F15821F4873200519EB7 /* RangeParsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
 		6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Uppsala.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BFF5EF721DA1EB700F4FBBB /* Uppsala.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Uppsala.h; sourceTree = "<group>"; };
 		6BFF5EF821DA1EB700F4FBBB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -75,7 +81,7 @@
 		6BFF5F8021DB50F000F4FBBB /* AlertControllerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertControllerFactoryTests.swift; sourceTree = "<group>"; };
 		6BFF5F9221DB658700F4FBBB /* RangeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParser.swift; sourceTree = "<group>"; };
 		6BFF5F9421DB6A5F00F4FBBB /* UppsalaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaResult.swift; sourceTree = "<group>"; };
-		6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParserTests.swift; sourceTree = "<group>"; };
+		6BFF5F9621DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParserTestsForSemanticVersion.swift; sourceTree = "<group>"; };
 		6BFF5F9921DB887400F4FBBB /* String+match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+match.swift"; sourceTree = "<group>"; };
 		6BFF5F9E21DB8CE100F4FBBB /* UppsalaResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaResultTests.swift; sourceTree = "<group>"; };
 		6BFF5FA121DC751000F4FBBB /* UpdateDetailJSONEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetailJSONEntity.swift; sourceTree = "<group>"; };
@@ -108,8 +114,9 @@
 		6B7C0FE821E2038900B0A6CD /* Parser */ = {
 			isa = PBXGroup;
 			children = (
+				6BD0F15821F4873200519EB7 /* RangeParsable.swift */,
 				6BFF5F9221DB658700F4FBBB /* RangeParser.swift */,
-				6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */,
+				6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */,
 			);
 			path = Parser;
 			sourceTree = "<group>";
@@ -117,9 +124,18 @@
 		6B7C0FEB21E20EE400B0A6CD /* Parser */ = {
 			isa = PBXGroup;
 			children = (
-				6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */,
+				6B7C0FF121E212AF00B0A6CD /* RangeParserTestsForDate.swift */,
+				6BFF5F9621DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift */,
 			);
 			path = Parser;
+			sourceTree = "<group>";
+		};
+		6B7C0FEC21E20FC000B0A6CD /* Date */ = {
+			isa = PBXGroup;
+			children = (
+				6B7C0FED21E20FEF00B0A6CD /* Date+RangeParsable.swift */,
+			);
+			path = Date;
 			sourceTree = "<group>";
 		};
 		6BFF5EEA21DA1EB700F4FBBB = {
@@ -186,6 +202,7 @@
 		6BFF5F1421DA5FEF00F4FBBB /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				6B7C0FEC21E20FC000B0A6CD /* Date */,
 				6BFF5F1621DA601000F4FBBB /* Environment */,
 				6B7C0FE821E2038900B0A6CD /* Parser */,
 				6BFF5FA021DC74FA00F4FBBB /* Update */,
@@ -478,12 +495,14 @@
 			files = (
 				6BFF5F1E21DB148500F4FBBB /* EnvironmentSource.swift in Sources */,
 				6BFF5F1C21DA64C200F4FBBB /* Bundle+.swift in Sources */,
+				6BD0F15921F4873200519EB7 /* RangeParsable.swift in Sources */,
 				6BFF5F7521DB38F600F4FBBB /* AlertControllerFactory.swift in Sources */,
 				6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */,
 				6BFF5F9321DB658700F4FBBB /* RangeParser.swift in Sources */,
-				6B7C0FEA21E203B200B0A6CD /* RangeParsable.swift in Sources */,
+				6B7C0FEE21E20FEF00B0A6CD /* Date+RangeParsable.swift in Sources */,
 				6BFF5F0F21DA43BC00F4FBBB /* SemanticVersion.swift in Sources */,
 				6BFF5FA421DC76A400F4FBBB /* UpdateDetailJSONFetcher.swift in Sources */,
+				6BD0F15721F475BB00519EB7 /* UppsalaRange.swift in Sources */,
 				6BFF5FA221DC751000F4FBBB /* UpdateDetailJSONEntity.swift in Sources */,
 				6B8ABEE621E093F700972E26 /* UpdateDetail.swift in Sources */,
 				6BFF5FB221DF852B00F4FBBB /* URLSession+fetch.swift in Sources */,
@@ -506,9 +525,10 @@
 				6BFF5F2721DB1A4000F4FBBB /* EnvironmentSourceAppTests.swift in Sources */,
 				6BFF5FA921DC7CA100F4FBBB /* UpdateDetailJSONEntityTests.swift in Sources */,
 				6BFF5F1121DA4D0900F4FBBB /* SemanticVersionTests.swift in Sources */,
+				6B7C0FF221E212AF00B0A6CD /* RangeParserTestsForDate.swift in Sources */,
 				6BFF5F6F21DB28DE00F4FBBB /* UppsalaTests.swift in Sources */,
 				6BFF5F2321DB186100F4FBBB /* EnvironmentTests.swift in Sources */,
-				6BFF5F9721DB80A500F4FBBB /* RangeParserTests.swift in Sources */,
+				6BFF5F9721DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift in Sources */,
 				6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Uppsala.xcodeproj/project.pbxproj
+++ b/Uppsala.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B7C0FEA21E203B200B0A6CD /* RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */; };
 		6B8ABEE621E093F700972E26 /* UpdateDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEE521E093F700972E26 /* UpdateDetail.swift */; };
 		6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */; };
 		6B8ABEEC21E0C32000972E26 /* Uppsala+fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */; };
@@ -25,9 +26,9 @@
 		6BFF5F6F21DB28DE00F4FBBB /* UppsalaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F6E21DB28DE00F4FBBB /* UppsalaTests.swift */; };
 		6BFF5F7521DB38F600F4FBBB /* AlertControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F7421DB38F600F4FBBB /* AlertControllerFactory.swift */; };
 		6BFF5F8121DB50F000F4FBBB /* AlertControllerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F8021DB50F000F4FBBB /* AlertControllerFactoryTests.swift */; };
-		6BFF5F9321DB658700F4FBBB /* SemanticVersionRangeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9221DB658700F4FBBB /* SemanticVersionRangeParser.swift */; };
+		6BFF5F9321DB658700F4FBBB /* RangeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9221DB658700F4FBBB /* RangeParser.swift */; };
 		6BFF5F9521DB6A5F00F4FBBB /* UppsalaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9421DB6A5F00F4FBBB /* UppsalaResult.swift */; };
-		6BFF5F9721DB80A500F4FBBB /* SemanticVersionRangeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9621DB80A500F4FBBB /* SemanticVersionRangeParserTests.swift */; };
+		6BFF5F9721DB80A500F4FBBB /* RangeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */; };
 		6BFF5F9A21DB887400F4FBBB /* String+match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9921DB887400F4FBBB /* String+match.swift */; };
 		6BFF5F9F21DB8CE100F4FBBB /* UppsalaResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5F9E21DB8CE100F4FBBB /* UppsalaResultTests.swift */; };
 		6BFF5FA221DC751000F4FBBB /* UpdateDetailJSONEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFF5FA121DC751000F4FBBB /* UpdateDetailJSONEntity.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
 		6B8ABEE521E093F700972E26 /* UpdateDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetail.swift; sourceTree = "<group>"; };
 		6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetailTests.swift; sourceTree = "<group>"; };
 		6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Uppsala+fetch.swift"; sourceTree = "<group>"; };
@@ -71,9 +73,9 @@
 		6BFF5F6E21DB28DE00F4FBBB /* UppsalaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaTests.swift; sourceTree = "<group>"; };
 		6BFF5F7421DB38F600F4FBBB /* AlertControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertControllerFactory.swift; sourceTree = "<group>"; };
 		6BFF5F8021DB50F000F4FBBB /* AlertControllerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertControllerFactoryTests.swift; sourceTree = "<group>"; };
-		6BFF5F9221DB658700F4FBBB /* SemanticVersionRangeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionRangeParser.swift; sourceTree = "<group>"; };
+		6BFF5F9221DB658700F4FBBB /* RangeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParser.swift; sourceTree = "<group>"; };
 		6BFF5F9421DB6A5F00F4FBBB /* UppsalaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaResult.swift; sourceTree = "<group>"; };
-		6BFF5F9621DB80A500F4FBBB /* SemanticVersionRangeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionRangeParserTests.swift; sourceTree = "<group>"; };
+		6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeParserTests.swift; sourceTree = "<group>"; };
 		6BFF5F9921DB887400F4FBBB /* String+match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+match.swift"; sourceTree = "<group>"; };
 		6BFF5F9E21DB8CE100F4FBBB /* UppsalaResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaResultTests.swift; sourceTree = "<group>"; };
 		6BFF5FA121DC751000F4FBBB /* UpdateDetailJSONEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetailJSONEntity.swift; sourceTree = "<group>"; };
@@ -103,6 +105,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6B7C0FE821E2038900B0A6CD /* Parser */ = {
+			isa = PBXGroup;
+			children = (
+				6BFF5F9221DB658700F4FBBB /* RangeParser.swift */,
+				6B7C0FE921E203B200B0A6CD /* RangeParsable.swift */,
+			);
+			path = Parser;
+			sourceTree = "<group>";
+		};
+		6B7C0FEB21E20EE400B0A6CD /* Parser */ = {
+			isa = PBXGroup;
+			children = (
+				6BFF5F9621DB80A500F4FBBB /* RangeParserTests.swift */,
+			);
+			path = Parser;
+			sourceTree = "<group>";
+		};
 		6BFF5EEA21DA1EB700F4FBBB = {
 			isa = PBXGroup;
 			children = (
@@ -152,7 +171,6 @@
 			isa = PBXGroup;
 			children = (
 				6BFF5F0E21DA43BC00F4FBBB /* SemanticVersion.swift */,
-				6BFF5F9221DB658700F4FBBB /* SemanticVersionRangeParser.swift */,
 			);
 			path = Versioning;
 			sourceTree = "<group>";
@@ -161,7 +179,6 @@
 			isa = PBXGroup;
 			children = (
 				6BFF5F1021DA4D0900F4FBBB /* SemanticVersionTests.swift */,
-				6BFF5F9621DB80A500F4FBBB /* SemanticVersionRangeParserTests.swift */,
 			);
 			path = Versioning;
 			sourceTree = "<group>";
@@ -170,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				6BFF5F1621DA601000F4FBBB /* Environment */,
+				6B7C0FE821E2038900B0A6CD /* Parser */,
 				6BFF5FA021DC74FA00F4FBBB /* Update */,
 				6BFF5F1221DA5E4300F4FBBB /* Versioning */,
 			);
@@ -180,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				6BFF5F2121DB182C00F4FBBB /* Environment */,
+				6B7C0FEB21E20EE400B0A6CD /* Parser */,
 				6BFF5FA521DC7C5400F4FBBB /* Update */,
 				6BFF5F1321DA5E5500F4FBBB /* Versioning */,
 			);
@@ -460,8 +479,9 @@
 				6BFF5F1E21DB148500F4FBBB /* EnvironmentSource.swift in Sources */,
 				6BFF5F1C21DA64C200F4FBBB /* Bundle+.swift in Sources */,
 				6BFF5F7521DB38F600F4FBBB /* AlertControllerFactory.swift in Sources */,
-				6BFF5F9321DB658700F4FBBB /* SemanticVersionRangeParser.swift in Sources */,
 				6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */,
+				6BFF5F9321DB658700F4FBBB /* RangeParser.swift in Sources */,
+				6B7C0FEA21E203B200B0A6CD /* RangeParsable.swift in Sources */,
 				6BFF5F0F21DA43BC00F4FBBB /* SemanticVersion.swift in Sources */,
 				6BFF5FA421DC76A400F4FBBB /* UpdateDetailJSONFetcher.swift in Sources */,
 				6BFF5FA221DC751000F4FBBB /* UpdateDetailJSONEntity.swift in Sources */,
@@ -488,7 +508,7 @@
 				6BFF5F1121DA4D0900F4FBBB /* SemanticVersionTests.swift in Sources */,
 				6BFF5F6F21DB28DE00F4FBBB /* UppsalaTests.swift in Sources */,
 				6BFF5F2321DB186100F4FBBB /* EnvironmentTests.swift in Sources */,
-				6BFF5F9721DB80A500F4FBBB /* SemanticVersionRangeParserTests.swift in Sources */,
+				6BFF5F9721DB80A500F4FBBB /* RangeParserTests.swift in Sources */,
 				6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### Issue
Close #10 

### Short Summary
- Change the parser logic to make `Date` parsable.
- Support semi-open range and single-bound ranges.

### What (will be changed by your commits)
- `RangeParser` now supports all comparable classes.

### Tested or Not (with some methods to test)
🙆 