### PR TITLE
Enable localization

### DIFF
--- a/Resources/Base.lproj/Localizable.strings
+++ b/Resources/Base.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"update_notification_title" = "Update Notification";
+"update_notification_message" = "The new version is now available!";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"update_notification_title" = "Update Notification";
+"update_notification_message" = "The new version is now available!";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,2 +1,0 @@
-"update_notification_title" = "Update Notification";
-"update_notification_message" = "The new version is now available!";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"update_notification_title" = "アップデートのお知らせ";
+"update_notification_message" = "新しいバージョンが利用可能です。";

--- a/Sources/Domain/Update/DialogTexts.swift
+++ b/Sources/Domain/Update/DialogTexts.swift
@@ -24,9 +24,20 @@ public struct DialogTexts {
        - message: The message of the dialog. `nil` will be replaced with the default text.
      */
     public init(title: String?, message: String?) {
-        // TODO: Localize
+        self.title = title ?? LocalizedStringKeys.notificationTitle.localized()
+        self.message = message ?? LocalizedStringKeys.notificationMessage.localized()
+    }
+}
+
+fileprivate extension DialogTexts {
+    /// Keys for fetching localized strings.
+    enum LocalizedStringKeys: String {
+        case notificationTitle = "update_notification_title"
+        case notificationMessage = "update_notification_message"
         
-        self.title = title ?? "Update Notification"
-        self.message = message ?? "The new version of this app is now available!"
+        /// Returns localized string.
+        func localized() -> String {
+            return self.rawValue.localized()
+        }
     }
 }

--- a/Sources/Extensions/Bundle+.swift
+++ b/Sources/Extensions/Bundle+.swift
@@ -7,6 +7,11 @@
 //
 
 extension Bundle {
+    /// The shorthand to access the `Bundle` for `Uppsala`.
+    static var uppsala: Bundle? {
+        return Bundle(identifier: "com.flyingalpaca.Uppsala")
+    }
+    
     /// The short version of app.
     var shortVersion: String? {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String

--- a/Sources/Extensions/String+localized.swift
+++ b/Sources/Extensions/String+localized.swift
@@ -1,0 +1,19 @@
+//
+//  String+localized.swift
+//  Uppsala
+//
+//  Created by Suita Fujino on 2019/02/02.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+extension String {
+    /**
+     Returns the localized string using the `self` value as a key.
+     
+     - Returns: The localized string.
+     */
+    func localized() -> String {
+        guard let bundle = Bundle.uppsala else { return self }
+        return NSLocalizedString(self, tableName: nil, bundle: bundle, comment: self)
+    }
+}

--- a/Tests/Domain/Parser/DialogTextsTests.swift
+++ b/Tests/Domain/Parser/DialogTextsTests.swift
@@ -1,0 +1,33 @@
+//
+//  DialogTextsTests.swift
+//  UppsalaTests
+//
+//  Created by Suita Fujino on 2019/02/02.
+//  Copyright © 2019 Suita Fujino. All rights reserved.
+//
+
+import XCTest
+@testable import Uppsala
+
+fileprivate struct Constants {
+    static let testTitle = "Hoge Title"
+    static let testMessage = "update plz plz plz:)"
+}
+
+class DialogTextsTests: XCTestCase {
+
+    func testInitializeWithExplicitStrings() {
+        let texts = DialogTexts(title: Constants.testTitle, message: Constants.testMessage)
+        
+        XCTAssertEqual(texts.title, Constants.testTitle)
+        XCTAssertEqual(texts.message, Constants.testMessage)
+    }
+    
+    func testInitializeWithNilArguments() {
+        let texts = DialogTexts(title: nil, message: nil)
+        
+        XCTAssertEqual(texts.title, "Update Notification")
+        XCTAssertEqual(texts.message, "The new version is now available!")
+    }
+
+}

--- a/Tests/Presentation/Gateway/UpdateDetailFetcherTests.swift
+++ b/Tests/Presentation/Gateway/UpdateDetailFetcherTests.swift
@@ -23,7 +23,7 @@ class UpdateDetailFetcherTests: XCTestCase {
             }
         }
         
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func testFetchAwaitShouldSucceed() {

--- a/Uppsala.xcodeproj/project.pbxproj
+++ b/Uppsala.xcodeproj/project.pbxproj
@@ -66,7 +66,6 @@
 		6BB210C422057A27007CE129 /* String+localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+localized.swift"; sourceTree = "<group>"; };
 		6BB210CC2205802F007CE129 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BB210D12205832A007CE129 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		6BB210D222058361007CE129 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BB210D322058E37007CE129 /* DialogTextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogTextsTests.swift; sourceTree = "<group>"; };
 		6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaRange.swift; sourceTree = "<group>"; };
 		6BD0F15821F4873200519EB7 /* RangeParsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
@@ -457,7 +456,6 @@
 			knownRegions = (
 				ja,
 				Base,
-				en,
 			);
 			mainGroup = 6BFF5EEA21DA1EB700F4FBBB;
 			productRefGroup = 6BFF5EF521DA1EB700F4FBBB /* Products */;
@@ -573,7 +571,6 @@
 			children = (
 				6BB210CC2205802F007CE129 /* ja */,
 				6BB210D12205832A007CE129 /* Base */,
-				6BB210D222058361007CE129 /* en */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Uppsala.xcodeproj/project.pbxproj
+++ b/Uppsala.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEF021E0D3FF00972E26 /* DialogTexts.swift */; };
 		6BB210C522057A27007CE129 /* String+localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB210C422057A27007CE129 /* String+localized.swift */; };
 		6BB210C922057FC6007CE129 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6BB210CB22057FC6007CE129 /* Localizable.strings */; };
+		6BB210D422058E37007CE129 /* DialogTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB210D322058E37007CE129 /* DialogTextsTests.swift */; };
 		6BD0F15721F475BB00519EB7 /* UppsalaRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */; };
 		6BD0F15921F4873200519EB7 /* RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15821F4873200519EB7 /* RangeParsable.swift */; };
 		6BFF5EFE21DA1EB800F4FBBB /* Uppsala.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */; };
@@ -66,6 +67,7 @@
 		6BB210CC2205802F007CE129 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BB210D12205832A007CE129 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BB210D222058361007CE129 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6BB210D322058E37007CE129 /* DialogTextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogTextsTests.swift; sourceTree = "<group>"; };
 		6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaRange.swift; sourceTree = "<group>"; };
 		6BD0F15821F4873200519EB7 /* RangeParsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
 		6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Uppsala.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +132,7 @@
 		6B7C0FEB21E20EE400B0A6CD /* Parser */ = {
 			isa = PBXGroup;
 			children = (
+				6BB210D322058E37007CE129 /* DialogTextsTests.swift */,
 				6B7C0FF121E212AF00B0A6CD /* RangeParserTestsForDate.swift */,
 				6BFF5F9621DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift */,
 			);
@@ -547,6 +550,7 @@
 				6BFF5F1121DA4D0900F4FBBB /* SemanticVersionTests.swift in Sources */,
 				6B7C0FF221E212AF00B0A6CD /* RangeParserTestsForDate.swift in Sources */,
 				6BFF5F6F21DB28DE00F4FBBB /* UppsalaTests.swift in Sources */,
+				6BB210D422058E37007CE129 /* DialogTextsTests.swift in Sources */,
 				6BFF5F2321DB186100F4FBBB /* EnvironmentTests.swift in Sources */,
 				6BFF5F9721DB80A500F4FBBB /* RangeParserTestsForSemanticVersion.swift in Sources */,
 				6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */,

--- a/Uppsala.xcodeproj/project.pbxproj
+++ b/Uppsala.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		6B8ABEE821E094F000972E26 /* UpdateDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */; };
 		6B8ABEEC21E0C32000972E26 /* Uppsala+fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */; };
 		6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8ABEF021E0D3FF00972E26 /* DialogTexts.swift */; };
+		6BB210C522057A27007CE129 /* String+localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB210C422057A27007CE129 /* String+localized.swift */; };
+		6BB210C922057FC6007CE129 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6BB210CB22057FC6007CE129 /* Localizable.strings */; };
 		6BD0F15721F475BB00519EB7 /* UppsalaRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */; };
 		6BD0F15921F4873200519EB7 /* RangeParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F15821F4873200519EB7 /* RangeParsable.swift */; };
 		6BFF5EFE21DA1EB800F4FBBB /* Uppsala.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */; };
@@ -60,6 +62,10 @@
 		6B8ABEE721E094F000972E26 /* UpdateDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDetailTests.swift; sourceTree = "<group>"; };
 		6B8ABEEB21E0C32000972E26 /* Uppsala+fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Uppsala+fetch.swift"; sourceTree = "<group>"; };
 		6B8ABEF021E0D3FF00972E26 /* DialogTexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DialogTexts.swift; path = Sources/Domain/Update/DialogTexts.swift; sourceTree = SOURCE_ROOT; };
+		6BB210C422057A27007CE129 /* String+localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+localized.swift"; sourceTree = "<group>"; };
+		6BB210CC2205802F007CE129 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6BB210D12205832A007CE129 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6BB210D222058361007CE129 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BD0F15621F475BB00519EB7 /* UppsalaRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UppsalaRange.swift; sourceTree = "<group>"; };
 		6BD0F15821F4873200519EB7 /* RangeParsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeParsable.swift; sourceTree = "<group>"; };
 		6BFF5EF421DA1EB700F4FBBB /* Uppsala.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Uppsala.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,11 +144,20 @@
 			path = Date;
 			sourceTree = "<group>";
 		};
+		6BB210C622057F55007CE129 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				6BB210CB22057FC6007CE129 /* Localizable.strings */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		6BFF5EEA21DA1EB700F4FBBB = {
 			isa = PBXGroup;
 			children = (
 				6BFF5EF621DA1EB700F4FBBB /* Sources */,
 				6BFF5F0121DA1EB800F4FBBB /* Tests */,
+				6BB210C622057F55007CE129 /* Resources */,
 				6BFF5EF521DA1EB700F4FBBB /* Products */,
 			);
 			sourceTree = "<group>";
@@ -225,7 +240,6 @@
 		6BFF5F1621DA601000F4FBBB /* Environment */ = {
 			isa = PBXGroup;
 			children = (
-				6BFF5F1B21DA64C200F4FBBB /* Bundle+.swift */,
 				6BFF5F1921DA62BB00F4FBBB /* Environment.swift */,
 				6BFF5F1D21DB148500F4FBBB /* EnvironmentSource.swift */,
 				6BFF5F1F21DB157E00F4FBBB /* EnvironmentSourceApp.swift */,
@@ -304,6 +318,8 @@
 		6BFF5F9821DB883C00F4FBBB /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				6BFF5F1B21DA64C200F4FBBB /* Bundle+.swift */,
+				6BB210C422057A27007CE129 /* String+localized.swift */,
 				6BFF5F9921DB887400F4FBBB /* String+match.swift */,
 				6BFF5FB121DF852B00F4FBBB /* URLSession+fetch.swift */,
 			);
@@ -436,6 +452,8 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				ja,
+				Base,
 				en,
 			);
 			mainGroup = 6BFF5EEA21DA1EB700F4FBBB;
@@ -454,6 +472,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BB210C922057FC6007CE129 /* Localizable.strings in Resources */,
 				6BFF5FB021DCC46700F4FBBB /* update_detail.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -495,6 +514,7 @@
 			files = (
 				6BFF5F1E21DB148500F4FBBB /* EnvironmentSource.swift in Sources */,
 				6BFF5F1C21DA64C200F4FBBB /* Bundle+.swift in Sources */,
+				6BB210C522057A27007CE129 /* String+localized.swift in Sources */,
 				6BD0F15921F4873200519EB7 /* RangeParsable.swift in Sources */,
 				6BFF5F7521DB38F600F4FBBB /* AlertControllerFactory.swift in Sources */,
 				6B8ABEF121E0D3FF00972E26 /* DialogTexts.swift in Sources */,
@@ -543,11 +563,25 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		6BB210CB22057FC6007CE129 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6BB210CC2205802F007CE129 /* ja */,
+				6BB210D12205832A007CE129 /* Base */,
+				6BB210D222058361007CE129 /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
 		6BFF5F0621DA1EB800F4FBBB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -612,6 +646,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/Uppsala.xcodeproj/xcshareddata/xcschemes/Uppsala.xcscheme
+++ b/Uppsala.xcodeproj/xcshareddata/xcschemes/Uppsala.xcscheme
@@ -56,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "en"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UppsalaSampleApp/UppsalaSampleApp/Info.plist
+++ b/UppsalaSampleApp/UppsalaSampleApp/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ja_JP</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/UppsalaSampleApp/UppsalaSampleApp/Resources/update_detail.json
+++ b/UppsalaSampleApp/UppsalaSampleApp/Resources/update_detail.json
@@ -1,6 +1,4 @@
 {
     "app_store_url": "https://www.apple.com",
-    "message": "Update plz:)",
-    "title": "Please Update!",
     "version": "1.1.12"
 }


### PR DESCRIPTION
### Issue
Close #12 

### Short Summary
- Add `Localizable.strings` to support multiple languages.
  - `en` and `ja`.

### What (will be changed by your commits)
- The default texts for the dialog will be replaced with localized strings.

### Tested or Not (with some methods to test)
🙆 